### PR TITLE
feat: CategoryInput에 name prop 추가 (기본값: categories)

### DIFF
--- a/src/components/ui/input/category-input.tsx
+++ b/src/components/ui/input/category-input.tsx
@@ -6,6 +6,7 @@ interface CategoryInputProps {
   className?: string;
   type?: "radio" | "checkbox";
   correctMessage?: string;
+  name?: string;
 }
 
 const CategoryInput = ({
@@ -13,10 +14,11 @@ const CategoryInput = ({
   type = "checkbox",
   correctMessage = "2개 선택 완료되었습니다.",
   className,
+  name = "categories",
 }: CategoryInputProps) => {
   return (
     <OptionInput
-      name="categories"
+      name={name}
       options={CATEGORIES}
       type={type}
       label={label}


### PR DESCRIPTION
## 📌 PR 제목
- feat: CategoryInput에 name prop 추가 (기본값: categories)

## 🔍 변경 사항
- CategoryInput에 name prop 추가 (기본값: categories)
  - 모임 생성 모달에서는 카테고리를 하나만 받기 때문에 name을 category로 설정했습니다.
  - 이를 위해 name prop을 추가하였습니다.
